### PR TITLE
fix wrong type bug

### DIFF
--- a/SurroundBirdEyeView/surroundBEV.py
+++ b/SurroundBirdEyeView/surroundBEV.py
@@ -271,8 +271,8 @@ class BlendMask:
         overlap = cv2.bitwise_and(maskA, maskB)
         indices = np.where(overlap != 0)
         for y, x in zip(*indices):
-            distA = cv2.pointPolygonTest(np.array(lineA), (x, y), True)
-            distB = cv2.pointPolygonTest(np.array(lineB), (x, y), True)
+            distA = cv2.pointPolygonTest(np.array(lineA), (int(x), int(y)), True)
+            distB = cv2.pointPolygonTest(np.array(lineB), (int(x), int(y)), True)
             maskA[y, x] = distA**2 / (distA**2 + distB**2 + 1e-6) * 255
         return maskA
     


### PR DESCRIPTION
fix a wrong type bug. 
```bash
silencht@ubuntu:~/CameraCalibration$ python3 main.py 
Intrinsic Calibration ......
./IntrinsicCalibration/data/img_raw0.jpg
./IntrinsicCalibration/data/img_raw5.jpg
./IntrinsicCalibration/data/img_raw6.jpg
./IntrinsicCalibration/data/img_raw9.jpg
./IntrinsicCalibration/data/img_raw4.jpg
./IntrinsicCalibration/data/img_raw8.jpg
./IntrinsicCalibration/data/img_raw3.jpg
./IntrinsicCalibration/data/img_raw1.jpg
./IntrinsicCalibration/data/img_raw7.jpg
./IntrinsicCalibration/data/img_raw2.jpg
Camera Matrix is : [[349.47115344324277, 0.0, 604.1864708236834], [0.0, 347.6868263975445, 530.960203577852], [0.0, 0.0, 1.0]]
Distortion Coefficient is : [[-0.0357727867533538], [0.0064262252846268506], [-0.0044955491700821], [0.00035552852913846994]]
Reprojection Error is : 0.0440129912824627
Extrinsic Calibration ......
Homography Matrix is:
[[0.06826314695299851, -0.5758378005243352, 414.7372611569021], [0.0008927841745232682, -0.7561327098542804, 632.243850736403], [-8.243429961708229e-07, -0.001146297857470799, 1.0]]
Generating Surround BEV ......
Traceback (most recent call last):
  File "main.py", line 98, in <module>
    main()
  File "main.py", line 95, in main
    runBEV()
  File "main.py", line 83, in runBEV
    bev = BevGenerator(blend=True, balance=True)        # 初始化环视鸟瞰图生成器
  File "/home/sunchanghe/Desktop/CameraCalibration/SurroundBirdEyeView/surroundBEV.py", line 293, in __init__
    self.masks = [BlendMask('front'), BlendMask('back'), 
  File "/home/sunchanghe/Desktop/CameraCalibration/SurroundBirdEyeView/surroundBEV.py", line 172, in __init__
    mf = self.get_blend_mask(mf, ml, self.lineFL, self.lineLF)
  File "/home/sunchanghe/Desktop/CameraCalibration/SurroundBirdEyeView/surroundBEV.py", line 274, in get_blend_mask
    distA = cv2.pointPolygonTest(np.array(lineA), (x, y), True)
cv2.error: OpenCV(4.6.0) :-1: error: (-5:Bad argument) in function 'pointPolygonTest'
> Overload resolution failed:
>  - Can't parse 'pt'. Sequence item with index 0 has a wrong type
>  - Can't parse 'pt'. Sequence item with index 0 has a wrong type
```